### PR TITLE
Updated to 1.1

### DIFF
--- a/MapReroll.csproj
+++ b/MapReroll.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MapReroll</RootNamespace>
     <AssemblyName>MapReroll</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
@@ -25,22 +25,24 @@
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <UseVSHostingProcess>true</UseVSHostingProcess>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>Mods\MapReroll\Assemblies\</OutputPath>
+    <OutputPath>Mods\MapReroll\v1.1\Assemblies\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\0Harmony.dll</HintPath>
+      <HintPath>..\packages\Lib.Harmony.2.0.0.8\lib\net472\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\RimworldManaged\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -49,8 +51,16 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine">
-      <HintPath>..\UnityEngine.dll</HintPath>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>..\RimworldManaged\UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.IMGUIModule">
+      <HintPath>..\RimworldManaged\UnityEngine.IMGUIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule">
+      <HintPath>..\RimworldManaged\UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -90,10 +100,6 @@
     <Compile Include="Source\UI\Widget_ResourceBalance.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\HugsLibChecker\HugsLibChecker.csproj">
-      <Project>{a7dea100-952b-4516-b020-b66c8bcb4b50}</Project>
-      <Name>HugsLibChecker</Name>
-    </ProjectReference>
     <ProjectReference Include="..\HugsLib\HugsLib.csproj">
       <Project>{a5d9bd45-533c-4ca0-9298-8950a3da724c}</Project>
       <Name>HugsLib</Name>

--- a/Mods/MapReroll/About/About.xml
+++ b/Mods/MapReroll/About/About.xml
@@ -2,9 +2,12 @@
 <ModMetaData>
 	<name>Map Reroll</name>
 	<author>UnlimitedHugs</author>
-	<targetVersion>1.0.0</targetVersion>
+	<supportedVersions>
+		<li>1.1</li>
+	</supportedVersions>
 	<url>https://ludeon.com/forums/index.php?topic=18073.0</url>
-		<description>Version: 2.4.0
+	<packageId>UnlimitedHugs.MapReroll</packageId>
+	<description>Version: 2.5.0
 	
 &lt;size=20&gt;Description&lt;/size&gt;
 Allows to randomize your starting maps and geyser locations until you find something you like.
@@ -17,5 +20,15 @@ Each page of previews and geyser reroll operation will cost you an amount of unm
 
 The resource cost is optional, and can be disabled in the Options &gt; Mod Settings menu.
 </description>	
-	
+	<modDependencies>
+		<li>
+			<packageId>UnlimitedHugs.HugsLib</packageId>
+			<displayName>HugsLib</displayName>
+			<downloadUrl>https://github.com/UnlimitedHugs/RimworldHugsLib/releases/latest</downloadUrl>
+			<steamWorkshopUrl>steam://url/CommunityFilePage/818773962</steamWorkshopUrl>
+		</li>
+	</modDependencies>
+	<loadAfter>
+		<li>UnlimitedHugs.HugsLib</li>
+	</loadAfter>
 </ModMetaData>

--- a/Mods/MapReroll/Assemblies/MapReroll.dll
+++ b/Mods/MapReroll/Assemblies/MapReroll.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a7345f9da9a959e8c394cf13b125a0df0762a3b884031302776b06b09cd479ca
-size 120320
+oid sha256:4ae45449cea05d3f66a71a756e08d4d07f6557a3a6c27ea25cc4e0e0784d97aa
+size 121344

--- a/Mods/MapReroll/LoadFolders.xml
+++ b/Mods/MapReroll/LoadFolders.xml
@@ -1,0 +1,6 @@
+<loadFolders>
+	<v1.1>
+		<li>/</li>
+		<li>v1.1</li>
+	</v1.1>
+</loadFolders>

--- a/Mods/MapReroll/v1.1/Assemblies/MapReroll.dll
+++ b/Mods/MapReroll/v1.1/Assemblies/MapReroll.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2369cfb09f7df57a27bd9645d0d3f26de3fc100d7a6c5f6b419fc8bb66bdb47f
+size 121344

--- a/Source/Compat_ConfigurableMaps.cs
+++ b/Source/Compat_ConfigurableMaps.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Linq;
-using Harmony;
+using HarmonyLib;
 using HugsLib;
 using MapReroll.UI;
 using RimWorld;
@@ -13,7 +13,7 @@ namespace MapReroll.Compat {
 	/// </summary>
 	public class Compat_ConfigurableMaps {
 
-		public static void Apply(HarmonyInstance harmonyInst) {
+		public static void Apply(Harmony harmonyInst) {
 			try {
 				if (GenTypes.GetTypeInAnyAssembly("ConfigurableMaps.HarmonyPatches") == null) return; // mod is not loaded
 				Dialog_MapPreviews.DialogOnGUI -= ExtraMapPreviewsDialogOnGUI;

--- a/Source/MapRerollController.cs
+++ b/Source/MapRerollController.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Harmony;
+using HarmonyLib;
 using HugsLib;
 using HugsLib.Settings;
 using HugsLib.Utils;

--- a/Source/MapRerollUtility.cs
+++ b/Source/MapRerollUtility.cs
@@ -18,7 +18,7 @@ namespace MapReroll {
 
 		public static string WithCostSuffix(string translationKey, PaidOperationType type, int desiredPreviewsPage = 0) {
 			var cost = RerollToolbox.GetOperationCost(type, desiredPreviewsPage);
-			var suffix = cost > 0 ? "Reroll2_costSuffix".Translate(cost.ToString("0.#")) : String.Empty;
+			var suffix = cost > 0 ? "Reroll2_costSuffix".Translate(cost.ToString("0.#")).ToString() : String.Empty;
 			return translationKey.Translate(suffix);
 		}
 

--- a/Source/Patches/ActiveDropPod_PodOpen_Patch.cs
+++ b/Source/Patches/ActiveDropPod_PodOpen_Patch.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Harmony;
+using HarmonyLib;
 using RimWorld;
 
 namespace MapReroll.Patches {

--- a/Source/Patches/CaravanEnterMapUtility_Enter_Patch.cs
+++ b/Source/Patches/CaravanEnterMapUtility_Enter_Patch.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Harmony;
+using HarmonyLib;
 using RimWorld.Planet;
 using Verse;
 

--- a/Source/Patches/DeterministicGenerationPatcher.cs
+++ b/Source/Patches/DeterministicGenerationPatcher.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Reflection;
-using Harmony;
+using HarmonyLib;
 using Verse;
 
 namespace MapReroll.Patches {
@@ -11,14 +11,14 @@ namespace MapReroll.Patches {
 		private const int DeterministicPatchPriority = 10;
 		private static bool generatorSeedPushed;
 
-		public static void InstrumentMethodForDeterministicGeneration(MethodInfo method, MethodInfo prefix, HarmonyInstance harmony) {
+		public static void InstrumentMethodForDeterministicGeneration(MethodInfo method, MethodInfo prefix, Harmony harmony) {
 			if (method == null) {
 				MapRerollController.Instance.Logger.Error($"Cannot instrument null method with prefix {prefix}: {Environment.StackTrace}");
 				return;
 			}
 			harmony.Patch(method, 
-				new HarmonyMethod(prefix) {prioritiy = DeterministicPatchPriority},
-				new HarmonyMethod(((Action)PopDeterministicRandState).Method) {prioritiy = -DeterministicPatchPriority});
+				new HarmonyMethod(prefix) {priority = DeterministicPatchPriority},
+				new HarmonyMethod(((Action)PopDeterministicRandState).Method) { priority = -DeterministicPatchPriority});
 		}
 
 		public static void DeterministicBeachSetup(Map map) {

--- a/Source/Patches/MapGenerator_GenerateMap_Patch.cs
+++ b/Source/Patches/MapGenerator_GenerateMap_Patch.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection.Emit;
-using Harmony;
+using HarmonyLib;
 using RimWorld.Planet;
 using Verse;
 using MapComponentUtility = Verse.MapComponentUtility;

--- a/Source/Patches/Rand_EnsureStateStackEmpty_Patch.cs
+++ b/Source/Patches/Rand_EnsureStateStackEmpty_Patch.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using Verse;
 
 namespace MapReroll.Patches {

--- a/Source/Patches/World_HasCaves_Patch.cs
+++ b/Source/Patches/World_HasCaves_Patch.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using RimWorld.Planet;
 
 namespace MapReroll.Patches {

--- a/Source/ReflectionCache.cs
+++ b/Source/ReflectionCache.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
-using Harmony;
+using HarmonyLib;
 using HugsLib.Utils;
 using RimWorld;
 using Verse;

--- a/Source/RerollToolbox.cs
+++ b/Source/RerollToolbox.cs
@@ -361,6 +361,7 @@ namespace MapReroll {
 		}
 
 		private static GameInitData MakeInitData(RerollWorldState state, Map sourceMap) {
+			var colonists = GetAllPlayerPawnsOnMap(sourceMap).Where(p => p.IsColonist).ToList();
 			return new GameInitData {
 				permadeath = Find.GameInfo.permadeathMode,
 				mapSize = sourceMap.Size.x,
@@ -368,7 +369,8 @@ namespace MapReroll {
 				startingSeason = Season.Undefined,
 				startedFromEntry = true,
 				startingTile = state.StartingTile,
-				startingAndOptionalPawns = GetAllPlayerPawnsOnMap(sourceMap).Where(p => p.IsColonist).ToList()
+				startingAndOptionalPawns = colonists,
+				startingPawnCount = colonists.Count
 			};
 		}
 

--- a/Source/UI/Dialog_MapPreviews.cs
+++ b/Source/UI/Dialog_MapPreviews.cs
@@ -165,7 +165,7 @@ namespace MapReroll.UI {
 
 				if (pageProvider.PageIsAvailable(pageProvider.CurrentPage + numPagesToTurn)) {
 					var paidNextBtnLabel = MapRerollUtility.WithCostSuffix("Reroll2_previews_nextPage", PaidOperationType.GeneratePreviews, pageProvider.CurrentPage + numPagesToTurn);
-					var nextBtnLabel = activeTab == previewsTab ? paidNextBtnLabel : "Reroll2_previews_nextPage".Translate("");
+					var nextBtnLabel = activeTab == previewsTab ? paidNextBtnLabel : "Reroll2_previews_nextPage".Translate("").ToString();
 					if (Widgets.ButtonText(new Rect(inRect.xMax - PageButtonSize.x, inRect.yMin, PageButtonSize.x, inRect.height), nextBtnLabel)) {
 						PageForward(pageProvider, numPagesToTurn);
 					}


### PR DESCRIPTION
Main issues that needed fixing were a compiler error with TaggedString comparing to String and the need to set startingPawnCount. Rest of the changes were just updates for HarmonyLib and removing HugsLibChecker.

Tried to match style/references as used in AllowTool.

Only other bug I found was an error when selecting a map before all previews finished generating, but that didn't break anything.