### PR TITLE
updating to work with the new version of configurable maps

### DIFF
--- a/Source/Compat/Compat_ConfigurableMaps.cs
+++ b/Source/Compat/Compat_ConfigurableMaps.cs
@@ -8,11 +8,14 @@ using RimWorld;
 using UnityEngine;
 using Verse;
 
-namespace MapReroll.Compat {
+namespace MapReroll.Compat
+{
 	/// <summary>
 	/// Compatibility tweaks to play nicely with Kiame's Configurable Maps
 	/// </summary>
-	public static class Compat_ConfigurableMaps {
+	public static class Compat_ConfigurableMaps
+	{
+		private static Assembly cmAssembly = null;
 
 		public static void Apply(Harmony harmonyInst) {
 			try {
@@ -20,14 +23,14 @@ namespace MapReroll.Compat {
 				Dialog_MapPreviews.DialogOnGUI -= ExtraMapPreviewsDialogOnGUI;
 				Dialog_MapPreviews.DialogOnGUI += ExtraMapPreviewsDialogOnGUI;
 				MapRerollController.Instance.Logger.Message("Applied Configurable Maps compatibility layer");
-			} catch (Exception e) {
+			}
+			catch (Exception e) {
 				MapRerollController.Instance.Logger.Error("Failed to apply compatibility layer for Configurable Maps:" + e);
 			}
 		}
 
 		// add a button to the previews dialog for easy access to terrain settings
 		private static void ExtraMapPreviewsDialogOnGUI(Dialog_MapPreviews previewsDialog, Rect inRect) {
-
 			var closeButtonSize = new Vector2(120f, 40f);
 			var configureButtonSize = new Vector2(140f, 40f);
 			var elementSpacing = 10f;
@@ -40,42 +43,80 @@ namespace MapReroll.Compat {
 					ReflectionCache.DialogModSettings_SelMod.SetValue(settingsDialog, mod);
 					Find.WindowStack.Add(settingsDialog);
 
+					Restore();
+
 					void TryReopenPreviews() {
+						UpdateConfigs();
 						if (Find.WindowStack.IsOpen(settingsDialog)) {
 							HugsLibController.Instance.DoLater.DoNextUpdate(TryReopenPreviews);
-						} else {
+						}
+						else {
 							Find.WindowStack.Add(new Dialog_MapPreviews());
 						}
 					}
 					TryReopenPreviews();
 				}
-				else
-                {
+				else {
 					Log.Error("Failed to load config maps");
-                }
+				}
 			}
 		}
 
 		private static bool TryGetMod(out Mod mod) {
-			foreach (ModContentPack pack in LoadedModManager.RunningMods) {
-				foreach (Assembly assembly in pack.assemblies.loadedAssemblies) {
-					Type t = assembly.GetType("ConfigurableMaps.SettingsController");
-					if (t != null) {
-						try {
-							// This will have the window open to map settings
-							// Wrapping in a try/catch just in case this ever changes it won't cause map reroll to crash
-							assembly.GetType("ConfigurableMaps.Settings").GetMethod("OpenOnMapSettings", BindingFlags.Public | BindingFlags.Static).Invoke(null, null);
-						}
-						catch {
-							Log.Warning("failed to set to open to map settings");
-						}
-						mod = LoadedModManager.GetMod(t);
-						return mod != null;
+			if (LoadAssembly()) {
+				Type t = cmAssembly.GetType("ConfigurableMaps.SettingsController");
+				if (t != null) {
+					try {
+						// This will have the window open to map settings
+						// Wrapping in a try/catch just in case this ever changes it won't cause map reroll to crash
+						cmAssembly.GetType("ConfigurableMaps.Settings").GetMethod("OpenOnMapSettings", BindingFlags.Public | BindingFlags.Static).Invoke(null, null);
 					}
+					catch {
+						Log.Warning("failed to set Configurable Maps' window to open the map settings page");
+					}
+					mod = LoadedModManager.GetMod(t);
+					return mod != null;
 				}
 			}
 			mod = null;
 			return false;
+		}
+
+		internal static void UpdateConfigs() {
+			if (LoadAssembly()) {
+				try {
+					cmAssembly.GetType("ConfigurableMaps.DefsUtil").GetMethod("Update", BindingFlags.Public | BindingFlags.Static).Invoke(null, null);
+					return;
+				}
+				catch { }
+			}
+			Log.Warning("Failed to Update Configurable Maps' settings prior to preview generation");
+		}
+
+		internal static void Restore() {
+			if (LoadAssembly()) {
+				try	{
+					cmAssembly.GetType("ConfigurableMaps.DefsUtil").GetMethod("Restore", BindingFlags.Public | BindingFlags.Static).Invoke(null, null);
+					return;
+				}
+				catch { }
+			}
+			Log.Warning("Failed to Restore Configurable Maps' settings after to preview generation");
+		}
+
+		private static bool LoadAssembly() {
+			if (cmAssembly == null) {
+				foreach (ModContentPack pack in LoadedModManager.RunningMods) {
+					foreach (Assembly assembly in pack.assemblies.loadedAssemblies) {
+						Type t = assembly.GetType("ConfigurableMaps.SettingsController");
+						if (t != null) {
+							cmAssembly = assembly;
+							return true;
+						}
+					}
+				}
+			}
+			return cmAssembly != null;
 		}
 	}
 }

--- a/Source/UI/GeneratedPreviewPageProvider.cs
+++ b/Source/UI/GeneratedPreviewPageProvider.cs
@@ -44,6 +44,9 @@ namespace MapReroll.UI {
 
 		private void EnsureEnoughPreviewsForPage(int page) {
 			while (previews.Count <= MaxIndexOnPage(page)) {
+				if (previews.Count == 0) {
+                    Compat.Compat_ConfigurableMaps.UpdateConfigs();
+				}
 				previews.Add(CreatePreview());
 			}
 		}


### PR DESCRIPTION
For 1.3 I rewrote Configurable Maps. As part of that rewrite I consolidates the two settings pages to one. That change caused this compat to stop working.